### PR TITLE
manuscrito estadística circular primera version

### DIFF
--- a/estadistica_circular/.gitignore
+++ b/estadistica_circular/.gitignore
@@ -1,0 +1,46 @@
+# History files
+.Rhistory
+.Rapp.history
+
+# Session Data files
+.RData
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+/*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+
+# Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
+rsconnect/
+.Rproj.user
+
+# html documents
+
+/*.html
+
+# figures
+
+/*.jpg
+

--- a/estadistica_circular/README.md
+++ b/estadistica_circular/README.md
@@ -1,0 +1,2 @@
+# Nota_estadistica_circular
+Nota para la revista ecosistema sobre estadística circular aplicada a la Ecología

--- a/estadistica_circular/ecosistemas.csl
+++ b/estadistica_circular/ecosistemas.csl
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="es-ES">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Ecosistemas (Spanish)</title>
+    <id>http://www.zotero.org/styles/ecosistemas</id>
+    <link href="http://www.zotero.org/styles/ecosistemas" rel="self"/>
+    <link href="http://www.zotero.org/styles/american-journal-of-botany" rel="template"/>
+    <link href="http://www.revistaecosistemas.net/public/journals/1/docs/Normasparaautores_RevistaEcosistemas.pdf" rel="documentation"/>
+    <link href="http://www.revistaecosistemas.net/index.php/ecosistemas/about/submissions#authorGuidelines" rel="documentation"/>
+    <author>
+      <name>Francisco Rodriguez-Sanchez</name>
+      <email>f.rodriguez.sanc@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
+    <category field="botany"/>
+    <category field="science"/>
+    <eissn>1697-2473</eissn>
+    <summary>Ecosistemas author-date style</summary>
+    <updated>2016-02-22T15:29:55+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short" strip-periods="true" prefix=" (" suffix=".),"/>
+    </names>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name font-variant="normal" font-weight="normal" delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" prefix=" " suffix=" "/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL" type="webpage">
+        <text value="Disponible en:" suffix=" "/>
+        <text variable="URL"/>
+        <group prefix=" [" suffix="]">
+          <text term="accessed" text-case="capitalize-first" suffix=" "/>
+          <date form="text" variable="accessed">
+            <date-part name="month"/>
+            <date-part name="day"/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year-suffix">
+    <sort>
+      <key macro="year-date"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=" ">
+        <group delimiter=", ">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <group>
+          <label variable="locator" suffix=" " form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="7">
+    <sort>
+      <key macro="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <text macro="author" suffix="."/>
+      <date variable="issued" prefix=" " suffix=".">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group prefix=" " delimiter=". " suffix=".">
+            <text macro="title"/>
+            <text macro="edition"/>
+            <text macro="editor"/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" " delimiter=" ">
+            <text term="in" text-case="capitalize-first" font-style="normal"/>
+            <text macro="editor"/>
+            <text variable="container-title" font-style="italic" suffix=","/>
+            <text variable="collection-title" suffix=","/>
+            <group suffix="." delimiter=". ">
+              <text variable="page" prefix="pp. "/>
+              <text macro="publisher" prefix=" "/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group prefix=" " suffix="." delimiter=". ">
+            <text macro="title"/>
+            <text variable="genre"/>
+            <text macro="publisher"/>
+          </group>
+        </else-if>
+        <else>
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor" prefix=" "/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <group prefix=" ">
+              <text variable="volume" suffix=": "/>
+            </group>
+            <group>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+      <text prefix=" " macro="access" suffix="."/>
+    </layout>
+  </bibliography>
+</style>

--- a/estadistica_circular/knitcitations_estadistica_circular.bib
+++ b/estadistica_circular/knitcitations_estadistica_circular.bib
@@ -1,0 +1,64 @@
+@Manual{Agostinelli_2017,
+  title = {{R} package \texttt{circular}: Circular Statistics (version 0.4-93)},
+  author = {C. Agostinelli and U. Lund},
+  address = {CA: Department of Environmental Sciences, Informatics
+and Statistics, Ca' Foscari University, Venice, Italy. UL: Department of Statistics, California Polytechnic State University, San Luis Obispo, California, USA},
+  year = {2017},
+  url = {https://r-forge.r-project.org/projects/circular/},
+}
+
+@Manual{Lund_2018,
+  title = {CircStats: Circular Statistics, from "Topics in Circular Statistics" (2001)},
+  author = {S-plus original by Ulric Lund and R port by Claudio Agostinelli},
+  year = {2018},
+  note = {R package version 0.2-6},
+  url = {https://CRAN.R-project.org/package=CircStats},
+}
+
+@Article{Monterroso_2014,
+  doi = {10.1007/s00265-014-1748-1},
+  url = {https://doi.org/10.1007/s00265-014-1748-1},
+  year = {2014},
+  month = {jun},
+  publisher = {Springer Science and Business Media {LLC}},
+  volume = {68},
+  number = {9},
+  pages = {1403--1417},
+  author = {Pedro Monterroso and Paulo C{\a'e}lio Alves and Pablo Ferreras},
+  title = {Plasticity in circadian activity patterns of mesocarnivores in Southwestern Europe: implications for species coexistence},
+  journal = {Behavioral Ecology and Sociobiology},
+}
+
+@Manual{R_Core_Team_2019,
+  title = {R: A Language and Environment for Statistical Computing},
+  author = {{R Core Team}},
+  organization = {R Foundation for Statistical Computing},
+  address = {Vienna, Austria},
+  year = {2019},
+  url = {https://www.R-project.org/},
+}
+
+@Manual{Rowcliffe_2019,
+  title = {activity: Animal Activity Statistics},
+  author = {Marcus Rowcliffe},
+  year = {2019},
+  note = {R package version 1.3},
+  url = {https://CRAN.R-project.org/package=activity},
+}
+
+@Manual{Tsagris_2020,
+  title = {Directional: Directional Statistics},
+  author = {Michail Tsagris and Giorgos Athineou and Anamul Sajib and Eli Amson and Micah J. Waldstein},
+  year = {2020},
+  note = {R package version 4.1},
+  url = {https://CRAN.R-project.org/package=Directional},
+}
+
+@Book{Wickham_2016,
+  author = {Hadley Wickham},
+  title = {ggplot2: Elegant Graphics for Data Analysis},
+  publisher = {Springer-Verlag New York},
+  year = {2016},
+  isbn = {978-3-319-24277-4},
+  url = {https://ggplot2.tidyverse.org},
+}

--- a/estadistica_circular/manuscript_estadistica_circular.Rmd
+++ b/estadistica_circular/manuscript_estadistica_circular.Rmd
@@ -1,0 +1,229 @@
+---
+title: "Estadística circular aplicada a la Ecología\n"
+  
+author: Irene Mendoza^1^
+
+csl: ecosistemas.csl  
+output:
+    word_document:
+    fig_caption: yes
+    fig_height: 8
+    fig_width: 10
+    highlight: null
+    reference_docx: estadistica_circular.docx
+    
+bibliography: 
+  - references_estadistica_circular.bib
+  - knitcitations_estadistica_circular.bib
+---
+
+
+> (1) Departamento de Ecología Integrativa. Estación Biológica de Doñana (CSIC).
+
+> Autor para correspondencia: Irene Mendoza [irene.mendoza@ebd.csic.es]
+
+
+## Palabras clave
+
+> fenología; actividad diaria; test de Rayleigh; test de Mardia-Watson-Wheeler
+
+
+## Keywords
+
+> phenology; diel activity; Rayleigh test; test de Mardia-Watson-Wheeler
+
+
+```{r knitcitations, echo=FALSE, cache = FALSE, warning = FALSE}
+library(knitcitations)
+library(RefManageR)
+library(bibtex)
+cleanbib()   
+cite_options(citation_format = "pandoc")
+```
+
+
+
+La estadística circular es una poderosa herramienta que permite analizar de forma apropiada variables que tienen una naturaleza cíclica y para los que la estadística linear no es correcta. Algunos ejemplos clásicos en Ecología incluyen el estudio de diferentes momentos de la floración o fructificación de una especie a lo largo del año, los patrones de actividad diarios de un mamífero, o las direcciones de vuelo de las mariposas. En estos casos, es importante destacar que la designación de un cero es completamente arbitraria y, por consiguiente, también la de valores mayores o menores. Por ejemplo, la diferencia entre el mes de enero y diciembre es de solo un mes en una escala circular, mientras que en una escala linear, dicha diferencia sería de 12 meses.
+
+# Transformación de nuestra variable de naturaleza circular en ángulos
+La primera medida que debemos hacer con nuestros datos de naturaleza circular es convertirlos en ángulos. Esto es fácilmente realizable con una simple ecuación [@Zar1999]: 
+
+
+$$
+a = \frac{(360º)(X)}{k}
+$$
+En la que *X* representa la variable temporal que queremos convertir en una dirección angular (en grados) y *k* es la cantidad total de unidades de tiempo de nuestra circunferencia (*k* = 365 para días del año, o *k* = 12 para meses, por ejemplo). De esta manera, el 14 de febrero, que es el día 45º del año, corresponde a 
+
+```{r ejemplo14feb, eval = TRUE, echo = TRUE}
+a <- 360*45/365
+```
+`r round(a, 2)` grados. En el caso de medidas mensuales, los 360º se dividen en 12 sectores de 30º. Por convención, se considera el punto medio del sector como el correspondiente a cada mes, es decir 15º para enero, 45º para febrero, ... y 345º para diciembre. 
+
+# Ejemplos usados y esquema de la nota
+En esta nota, vamos a usar dos ejemplos muy sencillos, uno referido a fenología de la fructificación en Nouragues (Guyana francesa) extraído de Mendoza *et al.* [-@Mendoza2018] y el otro a los patrones de actividad del agutí y del pecarí de la Isla de Barro Colorado [@Rowcliffe2014], extraídos del paquete `activity` `r citep(citation("activity"))`. Estos ejemplos permitirán mostrar cómo hacer representaciones gráficas circulares, calcular métricas circulares básicas y hacer inferencia sobre hipótesis de una y dos muestras. Utilizaremos R `r citep(citation())` para todos nuestros análisis, en concreto los tres paquetes de R que permiten analizar los datos circulares: `Directional` `r citep(citation("Directional"))`, `CircStats` `r citep(citation("CircStats"))`, y `circular` `r citep(citation("circular"))`, así como el paquete `ggplot2` `r citep(citation("ggplot2"))` para las representaciones gráficas. Debido a las limitaciones de espacio de esta nota, se recomienda revisar otras referencias para tener más detalle de los métodos, fórmulas exactas y aplicaciones a la Ecología de la estadística circular [@Batschelet1981; @Morellato2010; @MardiaJupp2000; @Staggemeier2020] . 
+
+```{r librarycall, eval = TRUE, echo = TRUE, warning = FALSE, message = FALSE}
+library(activity)
+library(circular)
+library(CircStats)
+library(Directional)
+library(ggplot2)
+```
+
+
+```{r dataexample, eval = TRUE, echo = TRUE}
+aguti <- subset(activity::BCItime, species == "agouti")
+pecari <- subset(activity::BCItime, species == "peccary")
+#se seleccionan los datos del agutí y pecarí de la base de datos BCItime del paquete activity. El tiempo de muestreo está expresado como una proporción relativa a las 24 horas de un día.
+
+frutofrq <- data.frame(meses = c("ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"), meses.ang = seq(15, 350, 30), numspp = c(21, 23, 32, 31, 29, 20, 19, 18, 15, 17, 21, 16))  #estos datos representan el número de especies en fruto por mes en Nouragues (extraído de Mendoza et al. 2018)         
+```
+
+# Representaciones gráficas de datos circulares
+
+El paquete `circular` `r citep(citation("circular"))` permite representar fácilmente los datos circulares que no están en frecuencias convirtiéndolos en un objeto `circular` usando la función `plot` (Fig. 1). 
+
+```{r circaguti, echo = TRUE, eval = FALSE}
+aguti.circ <- circular::circular(aguti$time*2*pi, units = "radians", template = "clock24")
+pecari.circ <- circular::circular(pecari$time*2*pi, units = "radians", template = "clock24")
+#convertimos en radianes los valores temporales
+
+plot (aguti.circ, main = "aguti") #Fig. 1
+plot(pecari.circ, main = "pecari")
+```
+
+
+Sin embargo, esta representación no es especialmente informativa. Es mucho más útil poder representar un histograma circular, en el que la longitud de cada barra representa la frecuencia de cada medida para cada ángulo (o unidad temporal). Para ello, podemos usar la función `windrose` del mismo paquete, pero la opción com mayor variedad de parámetros gráficos sin duda es a través de `ggplot2` usando la función `coord_polar`. Sin embargo, es preciso resaltar que estos diagramas de rosa tienden a [sesgar][sesgo_diagrama] al lector, sobre todo si el número de barras es bajo o el círculo interior pequeño. Se recomienda entonces usar la raiz cuadrada de las frecuencias como radios [@Zar1999].
+
+```{r cirhist, echo = TRUE, eval = FALSE}
+fig2 <- ggplot(frutofrq, aes(x = meses.ang, y = sqrt(numspp))) + geom_bar(stat='identity') + coord_polar() 
+```
+
+# Principales métricas circulares: media angular, desviación estándar angular y vector *r*
+
+La estadística linear no sirve para calcular estadísticos de datos circulares. Para eso, se han desarrollado métricas circulares como la media, varianza y desviación estándard circulares. Para conocer los detalles de las mismas, se recomienda Zar [-@Zar1999]. Estas métricas son fácilmente calculables usando la función `circ.summary` del paquete `Directional`.
+
+```{r circmetric, echo = TRUE, eval = TRUE}
+aguti.sum <- Directional::circ.summary(aguti$time*2*pi, plot = F) 
+
+aguti.sum$mesos #media angular en radianes
+
+aguti.sum$circstd #desviación estándard circular en radianes
+
+```
+En el caso de datos incluyendo frecuencias (como ocurre para los datos de fruto de Nouragues), se deben convertir las frecuencias en un vector único que repite cada valor angular el número de veces de su frecuencia. Una vez conseguido este vector, se podrá aplicar la función `circ.summary` como en el caso anterior. 
+
+```{r circmetricfreq, echo = TRUE, eval = TRUE}
+
+fruto <- c(rep(15,21), rep(45,23), rep(75,32), rep( 105, 31), rep(135, 29), rep(165,20), rep(195,19), rep(225,18), rep(255, 15), rep(285, 17), rep(315, 21), rep(345, 16))
+
+fruto.sum <-  Directional::circ.summary(fruto*pi/180, plot = F, rads = T) #convertimos en radianes los valores temporales
+
+```
+De estas métricas, *MRL* representa  el vector de la longitud de la media o vector *r*. Es un valor adimensional que se utiliza en fenología como una estima de la concentración de la actividad o la estacionalidad de la fenofase, siendo mayor cuanto más cercano a 1. Así por ejemplo, el valor de *r* = `r round(aguti.sum$MRL, 5)` para la actividad de los agutíes nos indica que está muy concentrada en el tiempo. En el caso de la fructificación en Nouragues, al estar los datos agrupados por meses, debemos multiplicar por un factor corrección $c<- (30*pi/360)/sin(30/2)$ al valor de *r* que se deriva de la función `circ.summary` `r c<- (30*pi/360)/sin(30/2)` *r* = `r round(fruto.sum$MRL*c, 2)`. El valor de *r* cercano a 0 para estos datos nos indica que la estacionalidad de la fructificación es muy baja. 
+
+# Tests de uniformidad de una muestra: test de Rayleigh como medida de estacionalidad
+
+La forma de verificar estadísticamente si una distribución circular es significativamente estacional es usando el *test de Rayleigh*. Este test tiene como hipótesis nula que la distribución circular es uniforme, es decir, que no tiene una dirección media angular. Para ello, es un requisito indispensable que la distribución sea unimodal, aunque si los datos fueran bimodales y estuvieran repartidos a lo largo del círculo, podríamos trabajar con las dos medias circunferencias por separado.
+
+```{r rtest, echo = TRUE, eval = TRUE}
+CircStats::r.test(fruto, degree = T)
+CircStats::r.test(aguti$time*2*pi, degree = F)
+
+```
+Gracias a este test podemos ver que, a pesar de que el valor de *r* para Nouragues sea bajo, la fructificación es significativamente estacional, con un pico en marzo-mayo.
+
+# Tests entre dos distribuciones circulares: test de Mardia-Watson-Wheeler aplicado a los patrones actividad de los animales
+
+Muchas trabajos (ver `r citet("10.1007/s00265-014-1748-1")` como ejemplo) analizan los patrones de actividad diaria de diferentes especies animales usando el test de Mardia-Watson-Wheeler [@Batschelet1981]. Este test permite detectar si dos muestras circulares difieren significativamente entre sí de una forma no paramétrica. Para ello, las dos muestras se mezclan, se distribuyen uniformente y se calculan sus rangos circulares. Si las dos muestras son similares, la distribución de sus rangos también debería serlo, aceptándose la hipótesis nula.
+
+```{r density, echo = FALSE, eval = FALSE}
+dens <- density2(aguti$time, from=0.25, to=0.75)
+plot(dens)
+mod1 <- fitact(aguti$time * 2 * pi)
+plot(mod1)
+
+dens2 <- density2(pecari$time, from=0.25, to=0.75)
+plot(dens2, main = "pecari")
+mod2 <- fitact(pecari$time * 2 * pi)
+plot(mod2, main = "pecari")
+
+```
+La forma más sencilla de calcular este test es usando la función `watson.wheeler.test` del paquete `circular`. 
+
+```{r mardiatest, echo = TRUE, eval = TRUE, warning = FALSE}
+aguti.circ <- circular::circular(aguti$time*2*pi, units = "radians", template = "clock24")
+pecari.circ <- circular::circular(pecari$time*2*pi, units = "radians", template = "clock24")
+
+circular::watson.wheeler.test(list(aguti.circ, pecari.circ))
+
+```
+Usamos el ejemplo de los datos de actividad del agutí y el pecarí. Como se podía apreciar por los gráficos de la Fig. 1, el test nos demuestra que el patrón de actividad de las dos especies es significativamente diferente.
+
+# Consideraciones finales
+En esta nota apenas hemos pincelado algunas aplicaciones básicas de la estadística circular  a la Ecología, especialmente para la fenología o el estudio de patrones de actividad diaria de animales, pero obviamente hay muchas más posibilidades. No hemos comentado otros tests importantes ni tampoco las correlaciones circular-linear o circular-circular por falta de espacio, por ejemplo. Gracias a la funcionalidad de los paquetes de *R* especializados en estadística circular, estas métricas y análisis están fácilmente disponibles, con lo que el usuario interesado podrá seguir avanzando en la aplicación de una poderosa herramienta estadística.
+
+El código necesario para reproducir este documento se puede consultar en [GitHub][github_nota].
+
+[sesgo_diagrama]: https://www.data-to-viz.com/caveat/circular_bar_yaxis.html
+[github_nota]: https://github.com/iremendoza/Nota_estadistica_circular
+
+# Agradecimientos
+
+Esta nota es un producto del proyecto TEMPNET, financiado con una beca Marie-Sklodowska Curie (798269 - TEMPNET - H2020-MSCA-IF-2017/H2020-MSCA-IF-2017).
+
+
+
+### REFERENCIAS
+
+```{r write_citations, cache=FALSE, include=FALSE}
+write.bibtex(file = "knitcitations_estadistica_circular.bib")
+```
+
+<div id = "refs"></div>
+
+
+###### PIES DE FIGURA
+
+**Figura 1**. Diagrama circular representando la actividad diaria del agutí y el pecarí en la Isla de Barro Colorado. (Datos extraídos de Rowcliffe *et al.* 2014).
+
+**Figura 2**. Histograma circular representando el número de especies con fruto en cada mes del año en la reserva de Nouragues (Guyana Francesa). Datos extraídos de Mendoza *et al.* 2018. El código para representar esta figura se puede ver en el texto. 
+
+###### FIGURA 1
+
+```{r Fig1, echo=FALSE, fig.cap="Figura 1.", cache=FALSE, fig.fullwidth = T}
+aguti.circ <- circular::circular(aguti$time*2*pi, units = "radians", template = "clock24") #convertimos en radianes los valores temporales
+par(mfrow = c(1,2))
+plot (aguti.circ, main = "aguti")
+plot(pecari.circ, main = "pecari")
+```
+
+
+###### FIGURA 2
+
+```{r Fig2, echo=FALSE, fig.cap="Figura 2.", cache=FALSE}
+library(ggplot2)
+
+ggplot(frutofrq, aes(x = meses.ang, y = sqrt(numspp))) + geom_bar(stat='identity') + coord_polar() + 
+scale_y_continuous( breaks = c(0,2,4,6), labels = c("0", "4", "16", "36")) +
+#ylim(0, 6.3) +
+geom_text(aes(y = 6.5, label = meses))  +  xlab(label ="meses")+ ylab(label ="número de especies en fruto") + 
+  theme_bw() + 
+  theme(axis.text = element_text(size = 12, colour = "black"),
+        axis.text.x = element_blank(),
+        axis.title = element_text(size = 15, colour = "black"))
+
+
+```
+
+
+
+
+
+
+
+
+
+
+
+

--- a/estadistica_circular/references_estadistica_circular.bib
+++ b/estadistica_circular/references_estadistica_circular.bib
@@ -1,0 +1,129 @@
+@Inbook{Morellato2010,
+author="Morellato, L. Patricia C.
+and Alberti, L.F.
+and Hudson, Irene L.",
+editor="Hudson, Irene L.
+and Keatley, Marie R.",
+title="Applications of Circular Statistics in Plant Phenology: a Case Studies Approach",
+bookTitle="Phenological Research: Methods for Environmental and Climate Change Analysis",
+year="2010",
+publisher="Springer Netherlands",
+address="Dordrecht",
+pages="339--359",
+abstract="Phenology is the study of recurring biological events and its relationship to climate. Circular statistics is an area of statistics not very much used by ecologists nor by other researchers from the biological sciences, and indeed not much visited, till recently in statistical science. Nevertheless, the connection between the evaluation of temporal, recurring events and the analysis of directional data have converged in several papers, and show circular statistics to be an outstanding tool by which to better understand plant phenology. The aim of this chapter is to assess applications for circular statistics in plant phenology and its potential for phenological data analysis in general. We do not discuss the mathematics of circular statistics, but discuss its actual and potential applications to plant phenology. We provide several examples at various levels of application: from generating circular phenological variables to the actual testing of hypotheses, say, for the existence of certain a priori seasonal patterns. Circular statistics has particular value and application when flowering onset (or fruiting) occurs almost continuously in an annual cycle and importantly in southern climates, where flowering time may not have a logical starting point, such as mid-winter dormancy. We conclude circular statistics applies well to phenological research where we want to test for relationships between flowering time and other phenological traits (e.g. shoot growth), or with functional traits such as plant height. It also allows us to group species into annual, supra-annual, irregular and continuous reproducers; to study seasonality in reproduction and growth; and to assess synchronization of species.",
+isbn="978-90-481-3335-2",
+doi="10.1007/978-90-481-3335-2_16",
+url="https://doi.org/10.1007/978-90-481-3335-2_16"
+}
+
+@book{Zar1999,
+  author    = {Jerrold H. Zar}, 
+  title     = {Biostatistical Analysis},
+  publisher = {Prentice Hall},
+  year      = 1999,
+  address   = {New Jersey},
+  edition   = 4,
+  note      = {An optional note},
+  isbn      = {0-13-081542-X}
+}
+
+@book{Batschelet1981,
+  author    = {Edward Batschelet}, 
+  title     = {Circular Statistics in Biology},
+  publisher = {Academic Press},
+  year      = 1981,
+  address   = {London},
+  edition   = 1,
+  note      = {An optional note},
+  isbn      = {0-12-081050-6}
+}
+
+@Article{Yan2011,
+  title = {The Spread of Scientific Information: Insights from the Web Usage Statistics in PLoS Article-Level Metrics},
+  volume = {6},
+  issn = {1932-6203},
+  shorttitle = {The Spread of Scientific Information},
+  url = {http://dx.plos.org/10.1371/journal.pone.0019917},
+  doi = {10.1371/journal.pone.0019917},
+  number = {5},
+  urldate = {2013-12-10},
+  journal = {PLoS ONE},
+  author = {Koon-Kiu Yan and Mark Gerstein},
+  editor = {Alessandro Vespignani},
+  month = {may},
+  year = {2011},
+  pages = {e19917},
+  numeral = {1},
+}
+
+@Article{Sutherland2011,
+  title = {Quantifying the Impact and Relevance of Scientific Research},
+  volume = {6},
+  issn = {1932-6203},
+  url = {http://dx.plos.org/10.1371/journal.pone.0027537},
+  doi = {10.1371/journal.pone.0027537},
+  number = {11},
+  urldate = {2013-12-10},
+  journal = {PLoS ONE},
+  author = {William J. Sutherland and David Goulson and Simon G. Potts and Lynn V. Dicks},
+  editor = {Tammy Clifford},
+  month = {nov},
+  year = {2011},
+  pages = {e27537},
+  numeral = {1},
+}
+
+@article{Mendoza2018,
+author = {Mendoza, Irene and Condit, Richard S. and Wright, S. Joseph and Caubère, Adeline and Châtelet, Patrick and Hardy, Isabelle and Forget, Pierre-Michel},
+title = {Inter-annual variability of fruit timing and quantity at Nouragues (French Guiana): insights from hierarchical Bayesian analyses},
+journal = {Biotropica},
+
+volume = {50},
+number = {3},
+pages = {431-441},
+keywords = {Amazon Basin, dispersal modes, frugivory, long-term monitoring, phenology, rain forest, seed production},
+doi = {10.1111/btp.12560},
+url = {https://onlinelibrary.wiley.com/doi/abs/10.1111/btp.12560},
+eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1111/btp.12560},
+year = {2018}
+}
+
+@article{Rowcliffe2014,
+author = {Rowcliffe, J. Marcus and Kays, Roland and Kranstauber, Bart and Carbone, Chris and Jansen, Patrick A.},
+title = {Quantifying levels of animal activity using camera trap data},
+journal = {Methods in Ecology and Evolution},
+
+volume = {5},
+number = {11},
+pages = {1170-1179},
+keywords = {activity level, activity time, circular kernel, proportion active, remote sensors, Von Mises distribution, weighted kernel},
+doi = {10.1111/2041-210X.12278},
+url = {https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/2041-210X.12278},
+eprint = {https://besjournals.onlinelibrary.wiley.com/doi/pdf/10.1111/2041-210X.12278},
+abstract = {Summary Activity level (the proportion of time that animals spend active) is a behavioural and ecological metric that can provide an indicator of energetics, foraging effort and exposure to risk. However, activity level is poorly known for free-living animals because it is difficult to quantify activity in the field in a consistent, cost-effective and non-invasive way. This article presents a new method to estimate activity level with time-of-detection data from camera traps (or more generally any remote sensors), fitting a flexible circular distribution to these data to describe the underlying activity schedule, and calculating overall proportion of time active from this. Using simulations and a case study for a range of small- to medium-sized mammal species, we find that activity level can reliably be estimated using the new method. The method depends on the key assumption that all individuals in the sampled population are active at the peak of the daily activity cycle. We provide theoretical and empirical evidence suggesting that this assumption is likely to be met for many species, but may be less likely met in large predators, or in high-latitude winters. Further research is needed to establish stronger evidence on the validity of this assumption in specific cases; however, the approach has the potential to provide an effective, non-invasive alternative to existing methods for quantifying population activity levels.},
+year = {2014}
+}
+
+@book{MardiaJupp2000,
+  author    = {Kanti V. Mardia and Peter E. Jupp}, 
+  title     = {Directional Statistics},
+  publisher = {John Wiley & Sons},
+  year      = 2000,
+  address   = {Chichester},
+  edition   = 1,
+  note      = {An optional note},
+  isbn      = {0-471-95333-4}
+}
+
+@article{Staggemeier2020,
+author = {Staggemeier, Vanessa Graziele and Camargo, Maria Gabriela Gutierrez and Diniz-Filho, Jose Alexandre Felizola and Freckleton, Robert and Jardim, Lucas and Morellato, Leonor Patricia Cerdeira},
+title = {The circular nature of recurrent life cycle events: a test comparing tropical and temperate phenology},
+journal = {Journal of Ecology},
+volume = {108},
+number = {2},
+keywords = {circular statistics, climate seasonality, first flowering date, K-statistic, Mantel correlation, Pagel's lambda, phylogenetic eigenvector regression, phylogenetic signal},
+doi = {10.1111/1365-2745.13266},
+url = {https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/1365-2745.13266},
+eprint = {https://besjournals.onlinelibrary.wiley.com/doi/pdf/10.1111/1365-2745.13266},
+year = {2020}
+}


### PR DESCRIPTION
Tres años después, por fin va el manuscrito de estadística circular. Las figuras están un poco horrorosas en el Word, pero salen bien dentro del Markdown, las pondré con mayor resolución en la versión final. Me ha salido un poquito larga, pero es que el código ocupa mucho espacio. Ya sé que será pra el siguiente número de Ecosistemas, pero cualquier revisión es bienvenida!

Gracias,
Irene